### PR TITLE
[Card] add childrenStyle prop

### DIFF
--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -43,6 +43,11 @@ class Card extends Component {
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
+
+    /**
+     * Override the inline-styles of the children element.
+     */
+    childrenStyle: PropTypes.object
   };
 
   static defaultProps = {
@@ -110,17 +115,22 @@ class Card extends Component {
     const addBottomPadding = (lastElement && (lastElement.type.muiName === 'CardText' ||
       lastElement.type.muiName === 'CardTitle'));
     const {
-      style,
+      style
+      childrenStyle,
       ...other,
     } = this.props;
 
     const mergedStyles = Object.assign({
       zIndex: 1,
     }, style);
+    
+    const childrenMergedStyles = Object.assign({
+      paddingBottom: addBottomPadding ? 8 : 0,
+    }, childrenStyle);
 
     return (
       <Paper {...other} style={mergedStyles}>
-        <div style={{paddingBottom: addBottomPadding ? 8 : 0}}>
+        <div style={childrenMergedStyles}>
           {newChildren}
         </div>
       </Paper>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

add childrenStyle prop to have the ability to customize the inner div styles.
i needed this to give the div width of 100% then i can align the header to center and the body to left.
